### PR TITLE
BL-8460 Update vehicle type on re-subscription if vehicle type changed

### DIFF
--- a/motr-webapp/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/service/PendingSubscriptionService.java
+++ b/motr-webapp/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/service/PendingSubscriptionService.java
@@ -62,7 +62,8 @@ public class PendingSubscriptionService {
         PendingSubscriptionServiceResponse pendingSubscriptionResponse = new PendingSubscriptionServiceResponse();
 
         if (subscription.isPresent()) {
-            return getRedirectUrlWhenSubscriptionAlreadyExisis(subscription.get(), motDueDate, contactType, pendingSubscriptionResponse);
+            updateSubscriptionVehicleData(subscription.get(), motDueDate, vehicleType);
+            return getRedirectUrlWhenSubscriptionAlreadyExisis(contactType, pendingSubscriptionResponse);
         } else {
             return getRedirectUrlWhenNewSubscription(vrm, contact, motDueDate, motIdentification,
                     contactType, pendingSubscriptionResponse, vehicleType);
@@ -70,11 +71,8 @@ public class PendingSubscriptionService {
     }
 
     private PendingSubscriptionServiceResponse getRedirectUrlWhenSubscriptionAlreadyExisis(
-            Subscription subscription, LocalDate motDueDate,
             Subscription.ContactType contactType,
             PendingSubscriptionServiceResponse pendingSubscriptionResponse) {
-
-        updateSubscriptionMotDueDate(subscription, motDueDate);
 
         String redirectUri = (contactType == Subscription.ContactType.EMAIL
                 ? urlHelper.emailConfirmedNthTimeLink() : urlHelper.phoneConfirmedNthTimeLink());
@@ -155,9 +153,9 @@ public class PendingSubscriptionService {
         }
     }
 
-    private Subscription updateSubscriptionMotDueDate(Subscription subscription, LocalDate motDueDate) {
-
+    private Subscription updateSubscriptionVehicleData(Subscription subscription, LocalDate motDueDate, VehicleType vehicleType) {
         subscription.setMotDueDate(motDueDate);
+        subscription.setVehicleType(vehicleType);
         subscriptionRepository.save(subscription);
 
         return subscription;

--- a/motr-webapp/webapp/src/test/java/uk/gov/dvsa/motr/web/component/subscription/service/PendingSubscriptionServiceTest.java
+++ b/motr-webapp/webapp/src/test/java/uk/gov/dvsa/motr/web/component/subscription/service/PendingSubscriptionServiceTest.java
@@ -145,7 +145,7 @@ public class PendingSubscriptionServiceTest {
     }
 
     @Test
-    public void handleSubscriptionWithExistingSubscriptionWillUpdateMotExpiryDate() throws Exception {
+    public void handleSubscriptionWithExistingSubscriptionWillUpdateTestDueDateAndVehicleType() throws Exception {
 
         String originalEmail = EMAIL;
         String newEmailWithDifferentCase = originalEmail.toUpperCase();
@@ -156,10 +156,11 @@ public class PendingSubscriptionServiceTest {
 
         ContactDetail contactDetail = new ContactDetail(newEmailWithDifferentCase, CONTACT_TYPE_EMAIL);
         PendingSubscriptionServiceResponse pendingSubscriptionResponse = this.subscriptionService.handlePendingSubscriptionCreation(
-                TEST_VRM, contactDetail, date, new MotIdentification(TEST_MOT_TEST_NUMBER, TEST_DVLA_ID), VehicleType.MOT);
+                TEST_VRM, contactDetail, date, new MotIdentification(TEST_MOT_TEST_NUMBER, TEST_DVLA_ID), VehicleType.PSV);
 
         verify(subscriptionRepository, times(1)).save(subscriptionArgumentCaptor.capture());
         assertEquals(subscriptionArgumentCaptor.getValue().getMotDueDate(), date);
+        assertEquals(subscriptionArgumentCaptor.getValue().getVehicleType(), VehicleType.PSV);
         assertEquals(EMAIL_ALREADY_CONFIRMED_LINK, pendingSubscriptionResponse.getRedirectUri());
         assertNull(pendingSubscriptionResponse.getConfirmationId());
         verifyZeroInteractions(pendingSubscriptionRepository);
@@ -173,10 +174,11 @@ public class PendingSubscriptionServiceTest {
         ArgumentCaptor<Subscription> subscriptionArgumentCaptor = ArgumentCaptor.forClass(Subscription.class);
 
         PendingSubscriptionServiceResponse pendingSubscriptionResponse = this.subscriptionService.handlePendingSubscriptionCreation(
-                TEST_VRM, CONTACT_MOBILE, date, new MotIdentification(TEST_MOT_TEST_NUMBER, TEST_DVLA_ID), VehicleType.MOT);
+                TEST_VRM, CONTACT_MOBILE, date, new MotIdentification(TEST_MOT_TEST_NUMBER, TEST_DVLA_ID), VehicleType.PSV);
 
         verify(subscriptionRepository, times(1)).save(subscriptionArgumentCaptor.capture());
         assertEquals(subscriptionArgumentCaptor.getValue().getMotDueDate(), date);
+        assertEquals(subscriptionArgumentCaptor.getValue().getVehicleType(), VehicleType.PSV);
         assertEquals(PHONE_ALREADY_CONFIRMED_LINK, pendingSubscriptionResponse.getRedirectUri());
         assertNull(pendingSubscriptionResponse.getConfirmationId());
         verifyZeroInteractions(pendingSubscriptionRepository);


### PR DESCRIPTION
MOT tested vehicle can become HGV/PSV vehicle - during re-subscription for such vehicle
we have to update the vehicle type in subscription