### PR TITLE
BL-6332: Shorten SMS confirmation code from 6 to 5 characters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ allprojects {
         wiremockVersion = '2.12.0'
         systemRulesVersion = '1.16.0'
         commonsIoVersion = '2.5'
-        seleniumVersion = '2.53.1'
+        seleniumVersion = '3.141.59'
         orgTestingVersion = '6.10'
         uncommonsReportingVersion = '1.1.4'
         orgReflectionsVersion = '0.9.11'

--- a/motr-webapp/selenium/build.gradle
+++ b/motr-webapp/selenium/build.gradle
@@ -13,6 +13,7 @@ dependencies {
         exclude group: "org.testng", module: "testng"
     }
     compile "com.google.inject:guice:${guiceVersion}"
+    compile "commons-io:commons-io:${commonsIoVersion}"
 }
 
 task selenium(type: Test) {

--- a/motr-webapp/selenium/src/main/java/uk/gov/dvsa/motr/config/webdriver/DriverFactory.java
+++ b/motr-webapp/selenium/src/main/java/uk/gov/dvsa/motr/config/webdriver/DriverFactory.java
@@ -1,8 +1,10 @@
 package uk.gov.dvsa.motr.config.webdriver;
 
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -49,7 +51,11 @@ public class DriverFactory {
                 Logger.info("Javascript is enabled: " + String
                         .valueOf(capability.isJavascriptEnabled()));
                 capability.setCapability(FirefoxDriver.PROFILE, profile);
-                driver = MotBrowserFactory.createMotDriver(new FirefoxDriver(profile));
+
+                FirefoxOptions options = new FirefoxOptions();
+                options.setProfile(profile);
+
+                driver = MotBrowserFactory.createMotDriver(new FirefoxDriver(options));
                 break;
             }
             case CHROME: {

--- a/motr-webapp/webapp/src/integration-test/java/uk/gov/dvsa/motr/test/data/RandomDataUtil.java
+++ b/motr-webapp/webapp/src/integration-test/java/uk/gov/dvsa/motr/test/data/RandomDataUtil.java
@@ -70,6 +70,6 @@ public class RandomDataUtil {
 
     public static String confirmationCode() {
 
-        return random(6, false, true);
+        return random(5, false, true);
     }
 }

--- a/motr-webapp/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/service/ConfirmationCodeGenerator.java
+++ b/motr-webapp/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/service/ConfirmationCodeGenerator.java
@@ -4,9 +4,17 @@ import java.util.Random;
 
 class ConfirmationCodeGenerator {
 
+    private static final int MIN = 10000;
+    private static final int MAX = 99999;
+
+    /**
+     * Generates a random number between MIN and MAX.
+     *
+     * @return int Random integer between MIN and MAX.
+     */
     static String generateCode() {
 
-        Integer randomSixDigitCode = new Random().nextInt(900000) + 100000;
-        return randomSixDigitCode.toString();
+        int randomDigitCode = new Random().nextInt(MAX - MIN + 1) + MIN;
+        return Integer.toString(randomDigitCode);
     }
 }

--- a/motr-webapp/webapp/src/main/java/uk/gov/dvsa/motr/web/validator/SmsConfirmationCodeValidator.java
+++ b/motr-webapp/webapp/src/main/java/uk/gov/dvsa/motr/web/validator/SmsConfirmationCodeValidator.java
@@ -5,14 +5,14 @@ import java.util.regex.Pattern;
 
 public class SmsConfirmationCodeValidator implements FieldValidator {
 
-    private static final Pattern CONF_CODE_VALIDATION_REGEX = Pattern.compile("\\d{6}");
+    private static final Pattern CONF_CODE_VALIDATION_REGEX = Pattern.compile("\\d{5}");
 
-    public static final String EMPTY_CONFIRMATION_CODE_MESSAGE = "Enter 6-digit code from text message<br/>" +
+    public static final String EMPTY_CONFIRMATION_CODE_MESSAGE = "Enter 5-digit code from text message<br/>" +
             "<br/>It can take a couple of minutes for the text to arrive.";
-    public static final String EMPTY_CONFIRMATION_CODE_MESSAGE_AT_FIELD = "Enter 6 digits from text message";
+    public static final String EMPTY_CONFIRMATION_CODE_MESSAGE_AT_FIELD = "Enter 5 digits from text message";
     public static final String INVALID_CONFIRMATION_CODE_MESSAGE = "Entered code is invalid<br/>" +
-            "<br/>Enter 6 digits you received in text message";
-    public static final String INVALID_CONFIRMATION_CODE_MESSAGE_AT_FIELD = "Enter 6 digits from text message";
+            "<br/>Enter 5 digits you received in text message";
+    public static final String INVALID_CONFIRMATION_CODE_MESSAGE_AT_FIELD = "Enter 5 digits from text message";
 
     public static final String CODE_INCORRECT_3_TIMES = "You can’t subscribe now. <br/>" +
             "Code was entered incorrectly 3 times. <br/>" +

--- a/motr-webapp/webapp/src/main/resources/template/sms-confirmation-code.hbs
+++ b/motr-webapp/webapp/src/main/resources/template/sms-confirmation-code.hbs
@@ -14,7 +14,7 @@
 
             <h1 class="heading heading-large heading--large">One more step</h1>
 
-            <p>We sent you a text message with a 6-digit activation code, which expires in 24h. Enter the code on this page to activate your reminder.</p>
+            <p>We sent you a text message with a 5-digit activation code, which expires in 24h. Enter the code on this page to activate your reminder.</p>
 
             <form method="POST" autocomplete="off" novalidate="" action="confirm-phone">
 
@@ -26,7 +26,7 @@
                         {{/showInLine}}
                     </label>
 
-                    <input type="text" id="confirmationCode" name="confirmationCode" class="form-control" maxlength="6" value="{{confirmationCode}}">
+                    <input type="text" id="confirmationCode" name="confirmationCode" class="form-control" maxlength="5" value="{{confirmationCode}}">
                 </div>
 
                 <div class="form-group">

--- a/motr-webapp/webapp/src/test/java/uk/gov/dvsa/motr/web/component/subscription/service/ConfirmationCodeGeneratorTests.java
+++ b/motr-webapp/webapp/src/test/java/uk/gov/dvsa/motr/web/component/subscription/service/ConfirmationCodeGeneratorTests.java
@@ -2,14 +2,15 @@ package uk.gov.dvsa.motr.web.component.subscription.service;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ConfirmationCodeGeneratorTests {
 
     @Test
-    public void pseudoRandomConfirmationCodeIsSixCharactersLong() {
+    public void pseudoRandomConfirmationCodeIsFiveCharactersLong() {
 
         String id = ConfirmationCodeGenerator.generateCode();
-        assertTrue(id.length() == 6);
+        assertEquals(5, id.length());
     }
 }

--- a/motr-webapp/webapp/src/test/java/uk/gov/dvsa/motr/web/resource/SmsConfirmationCodeResourceTest.java
+++ b/motr-webapp/webapp/src/test/java/uk/gov/dvsa/motr/web/resource/SmsConfirmationCodeResourceTest.java
@@ -37,8 +37,8 @@ public class SmsConfirmationCodeResourceTest {
     private static final String CONFIRMATION_LINK = "CONFIRMATION_LINK";
     private static final String PHONE_NUMBER = "07801856718";
     private static final String CONFIRMATION_ID = "ABC123";
-    private static final String CONFIRMATION_CODE = "123456";
-    private static final String INVALID_CONFIRMATION_CODE = "654321";
+    private static final String CONFIRMATION_CODE = "12345";
+    private static final String INVALID_CONFIRMATION_CODE = "65432";
     private static final String VRM = "YN13NTX";
 
 

--- a/motr-webapp/webapp/src/test/java/uk/gov/dvsa/motr/web/validator/SmsConfirmationCodeValidatorTest.java
+++ b/motr-webapp/webapp/src/test/java/uk/gov/dvsa/motr/web/validator/SmsConfirmationCodeValidatorTest.java
@@ -26,7 +26,7 @@ public class SmsConfirmationCodeValidatorTest {
                 {"12"},
                 {"123"},
                 {"1234"},
-                {"12345"},
+                {"123456"},
                 {"1234567"},
                 {"a"},
                 {"abcdef"},
@@ -39,10 +39,10 @@ public class SmsConfirmationCodeValidatorTest {
     @DataProvider
     public static Object[][] validCodes() {
         return new Object[][]{
-                {"000000"},
-                {"123456"},
-                {"999999"},
-                {RandomStringUtils.randomNumeric(6)}
+                {"00000"},
+                {"12345"},
+                {"99999"},
+                {RandomStringUtils.randomNumeric(5)}
         };
     }
 


### PR DESCRIPTION
When a user subscribing for a text message MOT reminder, they are issued with a code to complete the initial set up of the subscription. The current code is 6 digits, this was changed to 5 digits to ensure it is as easy as possible for users to enter.

This merge request also updates the Selenium library version (with a small refactor); as previous version was no longer compatible with our pipeline.