### PR TITLE
BL-12038 - Content update for MOTR sign up page

### DIFF
--- a/motr-webapp/webapp/src/main/resources/template/notify/hgv-psv/signed-up-complete-email-body.txt
+++ b/motr-webapp/webapp/src/main/resources/template/notify/hgv-psv/signed-up-complete-email-body.txt
@@ -1,9 +1,5 @@
 ^#You’ve signed up for annual test (MOT) reminders
 
-Reminders for lorries, buses and large trailers are currently suspended.
-
-You will receive reminders for ((vehicle_details)) when the service restarts.
-
 You'll get a reminder every year until you unsubscribe.
 
 # The annual test changed on 20 May 2018

--- a/motr-webapp/webapp/src/main/resources/template/notify/hgv-psv/signed-up-complete-sms.txt
+++ b/motr-webapp/webapp/src/main/resources/template/notify/hgv-psv/signed-up-complete-sms.txt
@@ -1,1 +1,1 @@
-MOT reminder: You've signed up. Reminders are currently suspended. You will receive reminders for ((vehicle_vrm)) when the service restarts. Give us feedback at https://www.gov.uk/mot-survey To unsubscribe reply STOP ((vehicle_vrm))
+MOT reminder: You've signed up. Give us feedback at https://www.gov.uk/mot-survey To unsubscribe reply STOP ((vehicle_vrm))

--- a/motr-webapp/webapp/src/main/resources/template/vrm.hbs
+++ b/motr-webapp/webapp/src/main/resources/template/vrm.hbs
@@ -16,11 +16,6 @@
 
             <h1 class="heading heading-large heading--large">What is the vehicle’s registration number?</h1>
 
-            <div class="govuk-inset-text" style="font-size: 21px;">
-                <div>MOT reminders are currently suspended for lorries, buses and large trailers.</div>
-                <div>Please continue the sign-up process to receive reminders for your lorry, bus or large trailer when the service restarts.</div>
-            </div>
-
             <form method="POST" autocomplete="off" novalidate="" action="vrm">
 
                 <div class="form-group {{#message}}form-group-error{{/message}}" id="reg-number-input">


### PR DESCRIPTION
Remove text for HGV sign up:
Reminders for lorries, buses and large trailers are currently suspended.
You will receive reminders for ((vehicle_details)) when the service restarts.